### PR TITLE
Remove dependency on rh-aura

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,13 +13,13 @@ hex-literal = "0.1"
 slog = "^2"
 parity-codec = { version = "2.1" }
 trie-root = { git = "https://github.com/paritytech/trie" }
-sr-io = { git = "https://github.com/paritytech/substrate", branch = "rh-aura" }
-sr-primitives = { git = "https://github.com/paritytech/substrate", branch = "rh-aura" }
-substrate-cli = { git = "https://github.com/paritytech/substrate", branch = "rh-aura" }
-substrate-primitives = { git = "https://github.com/paritytech/substrate", branch = "rh-aura" }
-substrate-executor = { git = "https://github.com/paritytech/substrate", branch = "rh-aura" }
-substrate-service = { git = "https://github.com/paritytech/substrate", branch = "rh-aura" }
-substrate-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "rh-aura" }
-substrate-network = { git = "https://github.com/paritytech/substrate", branch = "rh-aura" }
-substrate-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "rh-aura" }
+sr-io = { git = "https://github.com/paritytech/substrate" }
+sr-primitives = { git = "https://github.com/paritytech/substrate" }
+substrate-cli = { git = "https://github.com/paritytech/substrate" }
+substrate-primitives = { git = "https://github.com/paritytech/substrate" }
+substrate-executor = { git = "https://github.com/paritytech/substrate" }
+substrate-service = { git = "https://github.com/paritytech/substrate" }
+substrate-transaction-pool = { git = "https://github.com/paritytech/substrate" }
+substrate-network = { git = "https://github.com/paritytech/substrate" }
+substrate-consensus-aura = { git = "https://github.com/paritytech/substrate" }
 node-runtime = { path = "../runtime" }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,21 +11,21 @@ serde_derive = { version = "1.0", optional = true }
 safe-mix = { version = "1.0", default-features = false }
 parity-codec = "2.0"
 parity-codec-derive = "2.0"
-sr-api = { git = "https://github.com/paritytech/substrate", branch = "rh-aura", default-features = false }
-sr-std = { git = "https://github.com/paritytech/substrate", branch = "rh-aura" }
-sr-io = { git = "https://github.com/paritytech/substrate", branch = "rh-aura" }
-srml-support = { git = "https://github.com/paritytech/substrate", branch = "rh-aura" }
-substrate-primitives = { git = "https://github.com/paritytech/substrate", branch = "rh-aura" }
-substrate-keyring = { git = "https://github.com/paritytech/substrate", branch = "rh-aura" }
-srml-balances = { git = "https://github.com/paritytech/substrate", branch = "rh-aura" }
-srml-consensus = { git = "https://github.com/paritytech/substrate", branch = "rh-aura" }
-srml-executive = { git = "https://github.com/paritytech/substrate", branch = "rh-aura" }
-sr-primitives = { git = "https://github.com/paritytech/substrate", branch = "rh-aura" }
-srml-system = { git = "https://github.com/paritytech/substrate", branch = "rh-aura" }
-srml-timestamp = { git = "https://github.com/paritytech/substrate", branch = "rh-aura" }
-srml-upgrade-key = { git = "https://github.com/paritytech/substrate", branch = "rh-aura" }
-substrate-client = { git = "https://github.com/paritytech/substrate", branch = "rh-aura", optional = true }
-sr-version = { git = "https://github.com/paritytech/substrate", branch = "rh-aura" }
+sr-api = { git = "https://github.com/paritytech/substrate", default-features = false }
+sr-std = { git = "https://github.com/paritytech/substrate",  }
+sr-io = { git = "https://github.com/paritytech/substrate",  }
+srml-support = { git = "https://github.com/paritytech/substrate", branch = "rmaster" }
+substrate-primitives = { git = "https://github.com/paritytech/substrate" }
+substrate-keyring = { git = "https://github.com/paritytech/substrate" }
+srml-balances = { git = "https://github.com/paritytech/substrate" }
+srml-consensus = { git = "https://github.com/paritytech/substrate" }
+srml-executive = { git = "https://github.com/paritytech/substrate" }
+sr-primitives = { git = "https://github.com/paritytech/substrate" }
+srml-system = { git = "https://github.com/paritytech/substrate" }
+srml-timestamp = { git = "https://github.com/paritytech/substrate" }
+srml-upgrade-key = { git = "https://github.com/paritytech/substrate" }
+substrate-client = { git = "https://github.com/paritytech/substrate", optional = true }
+sr-version = { git = "https://github.com/paritytech/substrate" }
 
 [features]
 default = ["std"]

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -7,23 +7,23 @@ authors = ["Parity Technologies <admin@parity.io>"]
 crate-type = ["cdylib"]
 
 [dependencies]
-integer-sqrt = { git = "https://github.com/paritytech/integer-sqrt-rs.git", branch = "master" }
+integer-sqrt = { git = "https://github.com/paritytech/integer-sqrt-rs.git" }
 safe-mix = { version = "1.0", default-features = false}
 parity-codec-derive = { version = "^2.1" }
 parity-codec = { version = "^2.1", default-features = false }
-substrate-primitives = { git = "https://github.com/paritytech/substrate", branch = "rh-aura", default-features = false }
-sr-api = { git = "https://github.com/paritytech/substrate", branch = "rh-aura", default-features = false }
-sr-std = { git = "https://github.com/paritytech/substrate", branch = "rh-aura", default-features = false }
-sr-io = { git = "https://github.com/paritytech/substrate", branch = "rh-aura", default-features = false }
-srml-support = { git = "https://github.com/paritytech/substrate", branch = "rh-aura", default-features = false }
-srml-balances = { git = "https://github.com/paritytech/substrate", branch = "rh-aura", default-features = false }
-srml-consensus = { git = "https://github.com/paritytech/substrate", branch = "rh-aura", default-features = false }
-srml-executive = { git = "https://github.com/paritytech/substrate", branch = "rh-aura", default-features = false }
-sr-primitives = { git = "https://github.com/paritytech/substrate", branch = "rh-aura", default-features = false }
-srml-system = { git = "https://github.com/paritytech/substrate", branch = "rh-aura", default-features = false }
-srml-timestamp = { git = "https://github.com/paritytech/substrate", branch = "rh-aura", default-features = false }
-srml-upgrade-key = { git = "https://github.com/paritytech/substrate", branch = "rh-aura", default-features = false }
-sr-version = { git = "https://github.com/paritytech/substrate", branch = "rh-aura", default-features = false }
+substrate-primitives = { git = "https://github.com/paritytech/substrate", default-features = false }
+sr-api = { git = "https://github.com/paritytech/substrate", default-features = false }
+sr-std = { git = "https://github.com/paritytech/substrate", default-features = false }
+sr-io = { git = "https://github.com/paritytech/substrate", default-features = false }
+srml-support = { git = "https://github.com/paritytech/substrate", default-features = false }
+srml-balances = { git = "https://github.com/paritytech/substrate", default-features = false }
+srml-consensus = { git = "https://github.com/paritytech/substrate", default-features = false }
+srml-executive = { git = "https://github.com/paritytech/substrate", default-features = false }
+sr-primitives = { git = "https://github.com/paritytech/substrate", default-features = false }
+srml-system = { git = "https://github.com/paritytech/substrate", default-features = false }
+srml-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false }
+srml-upgrade-key = { git = "https://github.com/paritytech/substrate", default-features = false }
+sr-version = { git = "https://github.com/paritytech/substrate", default-features = false }
 
 [features]
 default = []


### PR DESCRIPTION
closes #2 

rh-aura was merged into master and deleted on paritytech/substrate. rh-aura
caused build failures. Changed the dependencies to point to master.