### PR TITLE
Remove sr-api from node-template

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ substrate-service = { git = "https://github.com/paritytech/substrate" }
 substrate-transaction-pool = { git = "https://github.com/paritytech/substrate" }
 substrate-network = { git = "https://github.com/paritytech/substrate" }
 substrate-consensus-aura = { git = "https://github.com/paritytech/substrate" }
+substrate-client = { git = "https://github.com/paritytech/substrate", default-features = false }
 template-node-runtime = { path = "runtime" }
 
 [build-dependencies]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,7 +11,6 @@ serde_derive = { version = "1.0", optional = true }
 safe-mix = { version = "1.0", default-features = false }
 parity-codec = "2.0"
 parity-codec-derive = "2.0"
-sr-api = { git = "https://github.com/paritytech/substrate", default-features = false }
 sr-std = { git = "https://github.com/paritytech/substrate" }
 sr-io = { git = "https://github.com/paritytech/substrate" }
 srml-support = { git = "https://github.com/paritytech/substrate" }
@@ -32,7 +31,7 @@ default = ["std"]
 std = [
 	"parity-codec/std",
 	"substrate-primitives/std",
-	"sr-api/std",
+	"substrate-client/std",
 	"sr-std/std",
 	"sr-io/std",
 	"srml-support/std",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -29,6 +29,8 @@ extern crate srml_timestamp as timestamp;
 extern crate srml_balances as balances;
 extern crate srml_upgrade_key as upgrade_key;
 
+#[cfg(feature = "std")]
+use parity_codec::{Encode, Decode};
 use rstd::prelude::*;
 #[cfg(feature = "std")]
 use primitives::bytes;
@@ -37,7 +39,11 @@ use primitives::OpaqueMetadata;
 use runtime_primitives::{ApplyResult, transaction_validity::TransactionValidity,
 	Ed25519Signature, generic, traits::{self, BlakeTwo256, Block as BlockT}
 };
+#[cfg(feature = "std")]
+use runtime_primitives::traits::ApiRef;
 use client::{block_builder::api::runtime::*, runtime_api::{runtime::*, id::*}};
+#[cfg(feature = "std")]
+use client::runtime_api::ApiExt;
 use version::RuntimeVersion;
 #[cfg(feature = "std")]
 use version::NativeVersion;
@@ -200,6 +206,156 @@ pub type UncheckedExtrinsic = generic::UncheckedMortalExtrinsic<Address, Nonce, 
 pub type CheckedExtrinsic = generic::CheckedExtrinsic<AccountId, Nonce, Call>;
 /// Executive: handles dispatch to the various modules.
 pub type Executive = executive::Executive<Runtime, Block, Context, Balances, AllModules>;
+
+#[cfg(feature = "std")]
+use opaque::Block as GBlock;
+
+#[cfg(feature = "std")]
+pub struct ClientWithApi {
+	call: ::std::ptr::NonNull<client::runtime_api::CallApiAt<GBlock>>,
+	commit_on_success: ::std::cell::RefCell<bool>,
+	initialised_block: ::std::cell::RefCell<Option<GBlockId>>,
+	changes: ::std::cell::RefCell<client::runtime_api::OverlayedChanges>,
+}
+
+#[cfg(feature = "std")]
+unsafe impl Send for ClientWithApi {}
+#[cfg(feature = "std")]
+unsafe impl Sync for ClientWithApi {}
+
+#[cfg(feature = "std")]
+impl ApiExt for ClientWithApi {
+	fn map_api_result<F: FnOnce(&Self) -> Result<R, E>, R, E>(&self, map_call: F) -> Result<R, E> {
+		*self.commit_on_success.borrow_mut() = false;
+		let res = map_call(self);
+		*self.commit_on_success.borrow_mut() = true;
+
+		self.commit_on_ok(&res);
+
+		res
+	}
+}
+
+#[cfg(feature = "std")]
+impl client::runtime_api::ConstructRuntimeApi<GBlock> for ClientWithApi {
+	fn construct_runtime_api<'a, T: client::runtime_api::CallApiAt<GBlock>>(call: &'a T) -> ApiRef<'a, Self> {
+		ClientWithApi {
+			call: unsafe {
+				::std::ptr::NonNull::new_unchecked(
+					::std::mem::transmute(
+						call as &client::runtime_api::CallApiAt<GBlock>
+					)
+				)
+			},
+			commit_on_success: true.into(),
+			initialised_block: None.into(),
+			changes: Default::default(),
+		}.into()
+	}
+}
+
+#[cfg(feature = "std")]
+impl ClientWithApi {
+	fn call_api_at<A: Encode, R: Decode>(
+		&self,
+		at: &GBlockId,
+		function: &'static str,
+		args: &A
+	) -> client::error::Result<R> {
+		let res = unsafe {
+			self.call.as_ref().call_api_at(
+				at,
+				function,
+				args.encode(),
+				&mut *self.changes.borrow_mut(),
+				&mut *self.initialised_block.borrow_mut()
+			).and_then(|r|
+				R::decode(&mut &r[..])
+					.ok_or_else(||
+						client::error::ErrorKind::CallResultDecode(function).into()
+					)
+			)
+		};
+
+		self.commit_on_ok(&res);
+		res
+	}
+
+	fn commit_on_ok<R, E>(&self, res: &Result<R, E>) {
+		if *self.commit_on_success.borrow() {
+			if res.is_err() {
+				self.changes.borrow_mut().discard_prospective();
+			} else {
+				self.changes.borrow_mut().commit_prospective();
+			}
+		}
+	}
+}
+
+#[cfg(feature = "std")]
+type GBlockId = generic::BlockId<GBlock>;
+
+#[cfg(feature = "std")]
+impl client::runtime_api::Core<GBlock> for ClientWithApi {
+	fn version(&self, at: &GBlockId) -> Result<RuntimeVersion, client::error::Error> {
+		self.call_api_at(at, "version", &())
+	}
+
+	fn authorities(&self, at: &GBlockId) -> Result<Vec<AuthorityId>, client::error::Error> {
+		self.call_api_at(at, "authorities", &())
+	}
+
+	fn execute_block(&self, at: &GBlockId, block: &GBlock) -> Result<(), client::error::Error> {
+		self.call_api_at(at, "execute_block", block)
+	}
+
+	fn initialise_block(&self, at: &GBlockId, header: &<GBlock as BlockT>::Header) -> Result<(), client::error::Error> {
+		self.call_api_at(at, "initialise_block", header)
+	}
+}
+
+#[cfg(feature = "std")]
+impl client::block_builder::api::BlockBuilder<GBlock> for ClientWithApi {
+	fn apply_extrinsic(&self, at: &GBlockId, extrinsic: &<GBlock as BlockT>::Extrinsic) -> Result<ApplyResult, client::error::Error> {
+		self.call_api_at(at, "apply_extrinsic", extrinsic)
+	}
+
+	fn finalise_block(&self, at: &GBlockId) -> Result<<GBlock as BlockT>::Header, client::error::Error> {
+		self.call_api_at(at, "finalise_block", &())
+	}
+
+	fn inherent_extrinsics<Inherent: Decode + Encode, Unchecked: Decode + Encode>(
+		&self, at: &GBlockId, inherent: &Inherent
+	) -> Result<Vec<Unchecked>, client::error::Error> {
+		self.call_api_at(at, "inherent_extrinsics", inherent)
+	}
+
+	fn check_inherents<Inherent: Decode + Encode, Error: Decode + Encode>(&self, at: &GBlockId, block: &GBlock, inherent: &Inherent) -> Result<Result<(), Error>, client::error::Error> {
+		self.call_api_at(at, "check_inherents", &(block, inherent))
+	}
+
+	fn random_seed(&self, at: &GBlockId) -> Result<<GBlock as BlockT>::Hash, client::error::Error> {
+		self.call_api_at(at, "random_seed", &())
+	}
+}
+
+#[cfg(feature = "std")]
+impl client::runtime_api::TaggedTransactionQueue<GBlock> for ClientWithApi {
+	fn validate_transaction(
+		&self,
+		at: &GBlockId,
+		utx: &<GBlock as BlockT>::Extrinsic
+	) -> Result<TransactionValidity, client::error::Error> {
+		self.call_api_at(at, "validate_transaction", utx)
+	}
+}
+
+#[cfg(feature = "std")]
+impl client::runtime_api::Metadata<GBlock> for ClientWithApi {
+	fn metadata(&self, at: &GBlockId) -> Result<OpaqueMetadata, client::error::Error> {
+		self.call_api_at(at, "metadata", &())
+	}
+}
 
 // Implement our runtime API endpoints. This is just a bunch of proxying.
 impl_runtime_apis! {

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -12,7 +12,7 @@ safe-mix = { version = "1.0", default-features = false}
 parity-codec-derive = { version = "^2.1" }
 parity-codec = { version = "^2.1", default-features = false }
 substrate-primitives = { git = "https://github.com/paritytech/substrate", default-features = false }
-sr-api = { git = "https://github.com/paritytech/substrate", default-features = false }
+substrate-client = { git = "https://github.com/paritytech/substrate", default-features = false }
 sr-std = { git = "https://github.com/paritytech/substrate", default-features = false }
 sr-io = { git = "https://github.com/paritytech/substrate", default-features = false }
 srml-support = { git = "https://github.com/paritytech/substrate", default-features = false }
@@ -31,7 +31,7 @@ std = [
 	"safe-mix/std",
 	"parity-codec/std",
 	"substrate-primitives/std",
-	"sr-api/std",
+	"substrate-client/std",
 	"sr-std/std",
 	"sr-io/std",
 	"srml-support/std",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,9 +3,10 @@ use std::cell::RefCell;
 use tokio::runtime::Runtime;
 pub use substrate_cli::{VersionInfo, IntoExit, error};
 use substrate_cli::{prepare_execution, Action, informant};
-use service::{Factory, Service};
+use service::Factory;
 use substrate_service::{Components, ServiceFactory, Roles as ServiceRoles};
 use chain_spec;
+use std::ops::Deref;
 
 /// Parse command line arguments into service configuration.
 pub fn run<I, T, E>(args: I, exit: E, version: VersionInfo) -> error::Result<()> where
@@ -45,12 +46,13 @@ fn load_spec(id: &str) -> Result<Option<chain_spec::ChainSpec>, String> {
 	})
 }
 
-fn run_until_exit<C, E>(
+fn run_until_exit<T, C, E>(
 	runtime: &mut Runtime,
-	service: Service<C>,
+	service: T,
 	e: E,
 ) -> error::Result<()>
 	where
+		T: Deref<Target=substrate_service::Service<C>>,
 		C: Components,
 		E: IntoExit,
 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ extern crate log;
 extern crate substrate_cli;
 extern crate substrate_primitives as primitives;
 extern crate substrate_consensus_aura as consensus;
+extern crate substrate_client as client;
 #[macro_use]
 extern crate substrate_network as network;
 #[macro_use]

--- a/src/service.rs
+++ b/src/service.rs
@@ -11,6 +11,7 @@ use substrate_service::{
 	Roles, TaskExecutor,
 };
 use consensus::{import_queue, start_aura, Config as AuraConfig, AuraImportQueue};
+use client;
 
 pub use substrate_executor::NativeExecutor;
 // Our native executor instance.
@@ -28,24 +29,22 @@ construct_simple_protocol! {
 	pub struct NodeProtocol where Block = Block { }
 }
 
-construct_simple_service!(Service);
-
 construct_service_factory! {
 	struct Factory {
 		Block = Block,
 		RuntimeApi = ClientWithApi,
 		NetworkProtocol = NodeProtocol { |config| Ok(NodeProtocol::new()) },
 		RuntimeDispatch = Executor,
-		FullTransactionPoolApi = transaction_pool::ChainApi<FullBackend<Self>, FullExecutor<Self>, Block>
+		FullTransactionPoolApi = transaction_pool::ChainApi<client::Client<FullBackend<Self>, FullExecutor<Self>, Block, ClientWithApi>, Block>
 			{ |config, client| Ok(TransactionPool::new(config, transaction_pool::ChainApi::new(client))) },
-		LightTransactionPoolApi = transaction_pool::ChainApi<LightBackend<Self>, LightExecutor<Self>, Block>
+		LightTransactionPoolApi = transaction_pool::ChainApi<client::Client<LightBackend<Self>, LightExecutor<Self>, Block, ClientWithApi>, Block>
 			{ |config, client| Ok(TransactionPool::new(config, transaction_pool::ChainApi::new(client))) },
 		Genesis = GenesisConfig,
 		Configuration = (),
-		FullService = Service<FullComponents<Self>>
+		FullService = FullComponents<Self>
 			{ |config: FactoryFullConfiguration<Self>, executor: TaskExecutor| {
 				let is_auth = config.roles == Roles::AUTHORITY;
-				Service::<FullComponents<Factory>>::new(config, executor.clone()).map(move |service|{
+				FullComponents::<Factory>::new(config, executor.clone()).map(move |service|{
 					if is_auth {
 						if let Ok(Some(Ok(key))) = service.keystore().contents()
 							.map(|keys| keys.get(0).map(|k| service.keystore().load(k, "")))
@@ -69,8 +68,8 @@ construct_service_factory! {
 				})
 			}
 		},
-		LightService = Service<LightComponents<Self>>
-			{ |config, executor| Service::<LightComponents<Factory>>::new(config, executor) },
+		LightService = LightComponents<Self>
+			{ |config, executor| <LightComponents<Factory>>::new(config, executor) },
 		FullImportQueue = AuraImportQueue<Self::Block, FullClient<Self>>
 			{ |config, client| Ok(import_queue(AuraConfig {
 						local_key: None,

--- a/src/service.rs
+++ b/src/service.rs
@@ -4,7 +4,7 @@
 
 use std::sync::Arc;
 use transaction_pool::{self, txpool::{Pool as TransactionPool}};
-use template_node_runtime::{self, GenesisConfig, opaque::Block};
+use template_node_runtime::{self, GenesisConfig, opaque::Block, ClientWithApi};
 use substrate_service::{
 	FactoryFullConfiguration, LightComponents, FullComponents, FullBackend,
 	FullClient, LightClient, LightBackend, FullExecutor, LightExecutor,
@@ -33,6 +33,7 @@ construct_simple_service!(Service);
 construct_service_factory! {
 	struct Factory {
 		Block = Block,
+		RuntimeApi = ClientWithApi,
 		NetworkProtocol = NodeProtocol { |config| Ok(NodeProtocol::new()) },
 		RuntimeDispatch = Executor,
 		FullTransactionPoolApi = transaction_pool::ChainApi<FullBackend<Self>, FullExecutor<Self>, Block>


### PR DESCRIPTION
Changes to substrate broke this repo:
https://github.com/paritytech/substrate/pull/1094

These changes fix the substrate-node-template to get it working again now that sr-api is missing, along with some other changes.

Tested, and it compiles and runs find on my machine