### PR TITLE
set PROJECT_ROOT to source directory of a build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-PROJECT_ROOT=`git rev-parse --show-toplevel`
+PROJECT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 export CARGO_INCREMENTAL=0
 


### PR DESCRIPTION
Hi.

Set the PROJECT_ROOT to the source directory of the build.sh script.
With this change, `build.sh` keeps working in case the Git root moves to another location.
This happened to us as we used `substrate-node-new` and `substrate-ui-new` and moved it in one git monorepo.

PS: I took the solution from https://stackoverflow.com/questions/59895/getting-the-source-directory-of-a-bash-script-from-within#answer-246128

Cheers,
Fabian