### PR TITLE
rm unnecessary cd $ROOT

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,8 +12,6 @@ normal=$(tput sgr0)
 # Save current directory.
 pushd . >/dev/null
 
-cd $ROOT
-
 for SRC in runtime/wasm
 do
   echo "${bold}Building webassembly binary in $SRC...${normal}"


### PR DESCRIPTION
Also, $ROOT is not defined and the cmd will cd into $HOME.

Cheers,
Fabian