### PR TITLE
Update node template with generic AuthorityId

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+[*]
+indent_style=tab
+indent_size=tab
+tab_width=4
+end_of_line=lf
+charset=utf-8
+trim_trailing_whitespace=true
+max_line_length=120
+insert_final_newline=true
+
+[*.yml]
+indent_style=space
+indent_size=2
+tab_width=8
+end_of_line=lf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1647,7 +1647,7 @@ dependencies = [
 [[package]]
 name = "node-executor"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "node-primitives 0.1.0 (git+https://github.com/paritytech/substrate)",
@@ -1664,7 +1664,7 @@ dependencies = [
 [[package]]
 name = "node-primitives"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1678,7 +1678,7 @@ dependencies = [
 [[package]]
 name = "node-runtime"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "node-primitives 0.1.0 (git+https://github.com/paritytech/substrate)",
@@ -2451,7 +2451,7 @@ dependencies = [
 [[package]]
 name = "sr-api-macros"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2462,7 +2462,7 @@ dependencies = [
 [[package]]
 name = "sr-io"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "environmental 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.9.0 (git+https://github.com/paritytech/trie)",
@@ -2477,7 +2477,7 @@ dependencies = [
 [[package]]
 name = "sr-primitives"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "integer-sqrt 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2494,7 +2494,7 @@ dependencies = [
 [[package]]
 name = "sr-sandbox"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2506,7 +2506,7 @@ dependencies = [
 [[package]]
 name = "sr-std"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2514,7 +2514,7 @@ dependencies = [
 [[package]]
 name = "sr-version"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2527,7 +2527,7 @@ dependencies = [
 [[package]]
 name = "srml-aura"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2547,7 +2547,7 @@ dependencies = [
 [[package]]
 name = "srml-balances"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2566,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "srml-consensus"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2583,7 +2583,7 @@ dependencies = [
 [[package]]
 name = "srml-contract"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2603,7 +2603,7 @@ dependencies = [
 [[package]]
 name = "srml-council"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2623,7 +2623,7 @@ dependencies = [
 [[package]]
 name = "srml-democracy"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2642,7 +2642,7 @@ dependencies = [
 [[package]]
 name = "srml-executive"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2658,7 +2658,7 @@ dependencies = [
 [[package]]
 name = "srml-grandpa"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2678,7 +2678,7 @@ dependencies = [
 [[package]]
 name = "srml-metadata"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2691,7 +2691,7 @@ dependencies = [
 [[package]]
 name = "srml-session"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2711,7 +2711,7 @@ dependencies = [
 [[package]]
 name = "srml-staking"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2734,7 +2734,7 @@ dependencies = [
 [[package]]
 name = "srml-support"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mashup 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2751,7 +2751,7 @@ dependencies = [
 [[package]]
 name = "srml-support-procedural"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2763,7 +2763,7 @@ dependencies = [
 [[package]]
 name = "srml-support-procedural-tools"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2774,7 +2774,7 @@ dependencies = [
 [[package]]
 name = "srml-support-procedural-tools-derive"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2784,7 +2784,7 @@ dependencies = [
 [[package]]
 name = "srml-system"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2801,7 +2801,7 @@ dependencies = [
 [[package]]
 name = "srml-timestamp"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2818,7 +2818,7 @@ dependencies = [
 [[package]]
 name = "srml-treasury"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2836,7 +2836,7 @@ dependencies = [
 [[package]]
 name = "srml-upgrade-key"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2952,7 +2952,7 @@ dependencies = [
 [[package]]
 name = "substrate-cli"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2984,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "substrate-client"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3013,7 +3013,7 @@ dependencies = [
 [[package]]
 name = "substrate-client-db"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hash-db 0.9.0 (git+https://github.com/paritytech/trie)",
  "kvdb 0.1.0 (git+https://github.com/paritytech/parity-common?rev=616b40150ded71f57f650067fcbc5c99d7c343e6)",
@@ -3034,7 +3034,7 @@ dependencies = [
 [[package]]
 name = "substrate-consensus-aura"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3057,7 +3057,7 @@ dependencies = [
 [[package]]
 name = "substrate-consensus-aura-primitives"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-io 0.1.0 (git+https://github.com/paritytech/substrate)",
@@ -3071,7 +3071,7 @@ dependencies = [
 [[package]]
 name = "substrate-consensus-common"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3086,7 +3086,7 @@ dependencies = [
 [[package]]
 name = "substrate-executor"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3108,7 +3108,7 @@ dependencies = [
 [[package]]
 name = "substrate-finality-grandpa"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "finality-grandpa 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3130,7 +3130,7 @@ dependencies = [
 [[package]]
 name = "substrate-finality-grandpa-primitives"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3143,7 +3143,7 @@ dependencies = [
 [[package]]
 name = "substrate-keyring"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3153,7 +3153,7 @@ dependencies = [
 [[package]]
 name = "substrate-keystore"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3169,7 +3169,7 @@ dependencies = [
 [[package]]
 name = "substrate-network"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3192,7 +3192,7 @@ dependencies = [
 [[package]]
 name = "substrate-network-libp2p"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3215,7 +3215,7 @@ dependencies = [
 [[package]]
 name = "substrate-primitives"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3241,7 +3241,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git)",
@@ -3266,7 +3266,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-servers"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "jsonrpc-http-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git)",
  "jsonrpc-pubsub 9.0.0 (git+https://github.com/paritytech/jsonrpc.git)",
@@ -3280,7 +3280,7 @@ dependencies = [
 [[package]]
 name = "substrate-serializer"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3289,7 +3289,7 @@ dependencies = [
 [[package]]
 name = "substrate-service"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "exit-future 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-db"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3334,7 +3334,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-machine"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hash-db 0.9.0 (git+https://github.com/paritytech/trie)",
  "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3351,7 +3351,7 @@ dependencies = [
 [[package]]
 name = "substrate-telemetry"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3366,7 +3366,7 @@ dependencies = [
 [[package]]
 name = "substrate-transaction-graph"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3380,7 +3380,7 @@ dependencies = [
 [[package]]
 name = "substrate-transaction-pool"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3396,7 +3396,7 @@ dependencies = [
 [[package]]
 name = "substrate-trie"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hash-db 0.9.0 (git+https://github.com/paritytech/trie)",
  "memory-db 0.9.0 (git+https://github.com/paritytech/trie)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,7 +958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "jsonrpc-core"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/jsonrpc.git#711ce2a27fe8dca81493b02363c70b6295bb8aa0"
+source = "git+https://github.com/paritytech/jsonrpc.git#3604d9990f051b8b440961b0877a46140bb87a50"
 dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -970,7 +970,7 @@ dependencies = [
 [[package]]
 name = "jsonrpc-http-server"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/jsonrpc.git#711ce2a27fe8dca81493b02363c70b6295bb8aa0"
+source = "git+https://github.com/paritytech/jsonrpc.git#3604d9990f051b8b440961b0877a46140bb87a50"
 dependencies = [
  "hyper 0.12.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git)",
@@ -983,7 +983,7 @@ dependencies = [
 [[package]]
 name = "jsonrpc-macros"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/jsonrpc.git#711ce2a27fe8dca81493b02363c70b6295bb8aa0"
+source = "git+https://github.com/paritytech/jsonrpc.git#3604d9990f051b8b440961b0877a46140bb87a50"
 dependencies = [
  "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git)",
  "jsonrpc-pubsub 9.0.0 (git+https://github.com/paritytech/jsonrpc.git)",
@@ -993,7 +993,7 @@ dependencies = [
 [[package]]
 name = "jsonrpc-pubsub"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/jsonrpc.git#711ce2a27fe8dca81493b02363c70b6295bb8aa0"
+source = "git+https://github.com/paritytech/jsonrpc.git#3604d9990f051b8b440961b0877a46140bb87a50"
 dependencies = [
  "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1003,7 +1003,7 @@ dependencies = [
 [[package]]
 name = "jsonrpc-server-utils"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/jsonrpc.git#711ce2a27fe8dca81493b02363c70b6295bb8aa0"
+source = "git+https://github.com/paritytech/jsonrpc.git#3604d9990f051b8b440961b0877a46140bb87a50"
 dependencies = [
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "globset 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1019,7 +1019,7 @@ dependencies = [
 [[package]]
 name = "jsonrpc-ws-server"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/jsonrpc.git#711ce2a27fe8dca81493b02363c70b6295bb8aa0"
+source = "git+https://github.com/paritytech/jsonrpc.git#3604d9990f051b8b440961b0877a46140bb87a50"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git)",
@@ -1423,6 +1423,11 @@ dependencies = [
 
 [[package]]
 name = "linked-hash-map"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "linked-hash-map"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -1449,6 +1454,14 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lru-cache"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1664,7 +1677,7 @@ dependencies = [
 [[package]]
 name = "node-executor"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "node-primitives 0.1.0 (git+https://github.com/paritytech/substrate)",
@@ -1681,7 +1694,7 @@ dependencies = [
 [[package]]
 name = "node-primitives"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1695,7 +1708,7 @@ dependencies = [
 [[package]]
 name = "node-runtime"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "integer-sqrt 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2487,7 +2500,7 @@ dependencies = [
 [[package]]
 name = "sr-api-macros"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2498,7 +2511,7 @@ dependencies = [
 [[package]]
 name = "sr-io"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "environmental 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.9.0 (git+https://github.com/paritytech/trie)",
@@ -2513,7 +2526,7 @@ dependencies = [
 [[package]]
 name = "sr-primitives"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "integer-sqrt 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2530,19 +2543,19 @@ dependencies = [
 [[package]]
 name = "sr-sandbox"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-std 0.1.0 (git+https://github.com/paritytech/substrate)",
  "substrate-primitives 0.1.0 (git+https://github.com/paritytech/substrate)",
- "wasmi 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmi 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sr-std"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2550,7 +2563,7 @@ dependencies = [
 [[package]]
 name = "sr-version"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2563,7 +2576,7 @@ dependencies = [
 [[package]]
 name = "srml-aura"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2583,7 +2596,7 @@ dependencies = [
 [[package]]
 name = "srml-balances"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2602,7 +2615,7 @@ dependencies = [
 [[package]]
 name = "srml-consensus"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2619,7 +2632,7 @@ dependencies = [
 [[package]]
 name = "srml-contract"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2639,7 +2652,7 @@ dependencies = [
 [[package]]
 name = "srml-council"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2659,7 +2672,7 @@ dependencies = [
 [[package]]
 name = "srml-democracy"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2678,7 +2691,7 @@ dependencies = [
 [[package]]
 name = "srml-executive"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2694,7 +2707,7 @@ dependencies = [
 [[package]]
 name = "srml-grandpa"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2714,7 +2727,7 @@ dependencies = [
 [[package]]
 name = "srml-metadata"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2727,7 +2740,7 @@ dependencies = [
 [[package]]
 name = "srml-session"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2747,7 +2760,7 @@ dependencies = [
 [[package]]
 name = "srml-staking"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2770,7 +2783,7 @@ dependencies = [
 [[package]]
 name = "srml-sudo"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2789,7 +2802,7 @@ dependencies = [
 [[package]]
 name = "srml-support"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mashup 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2807,7 +2820,7 @@ dependencies = [
 [[package]]
 name = "srml-support-procedural"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2819,7 +2832,7 @@ dependencies = [
 [[package]]
 name = "srml-support-procedural-tools"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2830,7 +2843,7 @@ dependencies = [
 [[package]]
 name = "srml-support-procedural-tools-derive"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2840,7 +2853,7 @@ dependencies = [
 [[package]]
 name = "srml-system"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2857,7 +2870,7 @@ dependencies = [
 [[package]]
 name = "srml-timestamp"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2874,7 +2887,7 @@ dependencies = [
 [[package]]
 name = "srml-treasury"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2892,7 +2905,7 @@ dependencies = [
 [[package]]
 name = "srml-upgrade-key"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3006,9 +3019,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-basic-authorship"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
+dependencies = [
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-primitives 0.1.0 (git+https://github.com/paritytech/substrate)",
+ "substrate-client 0.1.0 (git+https://github.com/paritytech/substrate)",
+ "substrate-consensus-aura-primitives 0.1.0 (git+https://github.com/paritytech/substrate)",
+ "substrate-consensus-common 0.1.0 (git+https://github.com/paritytech/substrate)",
+ "substrate-primitives 0.1.0 (git+https://github.com/paritytech/substrate)",
+ "substrate-transaction-pool 0.1.0 (git+https://github.com/paritytech/substrate)",
+]
+
+[[package]]
 name = "substrate-cli"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3040,7 +3068,7 @@ dependencies = [
 [[package]]
 name = "substrate-client"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3069,12 +3097,13 @@ dependencies = [
 [[package]]
 name = "substrate-client-db"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "hash-db 0.9.0 (git+https://github.com/paritytech/trie)",
  "kvdb 0.1.0 (git+https://github.com/paritytech/parity-common?rev=616b40150ded71f57f650067fcbc5c99d7c343e6)",
  "kvdb-rocksdb 0.1.4 (git+https://github.com/paritytech/parity-common?rev=616b40150ded71f57f650067fcbc5c99d7c343e6)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3090,7 +3119,7 @@ dependencies = [
 [[package]]
 name = "substrate-consensus-aura"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3112,7 +3141,7 @@ dependencies = [
 [[package]]
 name = "substrate-consensus-aura-primitives"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-io 0.1.0 (git+https://github.com/paritytech/substrate)",
@@ -3126,7 +3155,7 @@ dependencies = [
 [[package]]
 name = "substrate-consensus-common"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3143,7 +3172,7 @@ dependencies = [
 [[package]]
 name = "substrate-executor"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3159,13 +3188,13 @@ dependencies = [
  "substrate-serializer 0.1.0 (git+https://github.com/paritytech/substrate)",
  "substrate-state-machine 0.1.0 (git+https://github.com/paritytech/substrate)",
  "substrate-trie 0.4.0 (git+https://github.com/paritytech/substrate)",
- "wasmi 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmi 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-finality-grandpa"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "finality-grandpa 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3187,7 +3216,7 @@ dependencies = [
 [[package]]
 name = "substrate-finality-grandpa-primitives"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3200,7 +3229,7 @@ dependencies = [
 [[package]]
 name = "substrate-keyring"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3210,7 +3239,7 @@ dependencies = [
 [[package]]
 name = "substrate-keystore"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3226,7 +3255,7 @@ dependencies = [
 [[package]]
 name = "substrate-network"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3249,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "substrate-network-libp2p"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3272,7 +3301,7 @@ dependencies = [
 [[package]]
 name = "substrate-primitives"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3291,13 +3320,13 @@ dependencies = [
  "sr-std 0.1.0 (git+https://github.com/paritytech/substrate)",
  "twox-hash 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmi 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmi 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-rpc"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git)",
@@ -3322,7 +3351,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-servers"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "jsonrpc-http-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git)",
  "jsonrpc-pubsub 9.0.0 (git+https://github.com/paritytech/jsonrpc.git)",
@@ -3336,7 +3365,7 @@ dependencies = [
 [[package]]
 name = "substrate-serializer"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3345,7 +3374,7 @@ dependencies = [
 [[package]]
 name = "substrate-service"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "exit-future 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3377,7 +3406,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-db"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3389,7 +3418,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-machine"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "hash-db 0.9.0 (git+https://github.com/paritytech/trie)",
  "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3406,7 +3435,7 @@ dependencies = [
 [[package]]
 name = "substrate-telemetry"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3421,7 +3450,7 @@ dependencies = [
 [[package]]
 name = "substrate-transaction-graph"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3435,7 +3464,7 @@ dependencies = [
 [[package]]
 name = "substrate-transaction-pool"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3451,7 +3480,7 @@ dependencies = [
 [[package]]
 name = "substrate-trie"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/substrate#a456f8f116f4999a5c0d6aac12a52d3a22abdc82"
+source = "git+https://github.com/paritytech/substrate#5dd23c2c51daaeffd757b50c007382d18dfeb63f"
 dependencies = [
  "hash-db 0.9.0 (git+https://github.com/paritytech/trie)",
  "memory-db 0.9.0 (git+https://github.com/paritytech/trie)",
@@ -3551,6 +3580,7 @@ dependencies = [
  "sr-io 0.1.0 (git+https://github.com/paritytech/substrate)",
  "sr-primitives 0.1.0 (git+https://github.com/paritytech/substrate)",
  "structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "substrate-basic-authorship 0.1.0 (git+https://github.com/paritytech/substrate)",
  "substrate-cli 0.3.0 (git+https://github.com/paritytech/substrate)",
  "substrate-client 0.1.0 (git+https://github.com/paritytech/substrate)",
  "substrate-consensus-aura 0.1.0 (git+https://github.com/paritytech/substrate)",
@@ -3906,7 +3936,7 @@ name = "twox-hash"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4067,7 +4097,7 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4360,10 +4390,12 @@ dependencies = [
 "checksum libp2p-websocket 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=d961e656a74d1bab5366d371a06f9e10d5f4a6c5)" = "<none>"
 "checksum libp2p-yamux 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=d961e656a74d1bab5366d371a06f9e10d5f4a6c5)" = "<none>"
 "checksum librocksdb-sys 5.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "474d805d72e23a06310fa5201dfe182dc4b80ab1f18bb2823c1ac17ff9dcbaa2"
+"checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
 "checksum make-cmd 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a8ca8afbe8af1785e09636acb5a41e08a765f5f0340568716c18a8700ba3c0d3"
 "checksum mashup 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f2d82b34c7fb11bb41719465c060589e291d505ca4735ea30016a91f6fc79c3b"
 "checksum mashup-impl 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "aa607bfb674b4efb310512527d64266b065de3f894fc52f84efcbf7eaa5965fb"
@@ -4520,6 +4552,7 @@ dependencies = [
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "670ad348dc73012fcf78c71f06f9d942232cdd4c859d4b6975e27836c3efc0c3"
 "checksum structopt-derive 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ef98172b1a00b0bec738508d3726540edcbd186d50dfd326f2b1febbb3559f04"
+"checksum substrate-basic-authorship 0.1.0 (git+https://github.com/paritytech/substrate)" = "<none>"
 "checksum substrate-cli 0.3.0 (git+https://github.com/paritytech/substrate)" = "<none>"
 "checksum substrate-client 0.1.0 (git+https://github.com/paritytech/substrate)" = "<none>"
 "checksum substrate-client-db 0.1.0 (git+https://github.com/paritytech/substrate)" = "<none>"
@@ -4605,7 +4638,7 @@ dependencies = [
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"
-"checksum wasmi 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8a60b9508cff2b7c27ed41200dd668806280740fadc8c88440e9c88625e84f1a"
+"checksum wasmi 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "21ef487a11df1ed468cf613c78798c26282da5c30e9d49f824872d4c77b47d1d"
 "checksum websocket 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c9faed2bff8af2ea6b9f8b917d3d00b467583f6781fe3def174a9e33c879703"
 "checksum which 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e84a603e7e0b1ce1aa1ee2b109c7be00155ce52df5081590d1ffb93f4f515cb2"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ substrate-network = { git = "https://github.com/paritytech/substrate" }
 substrate-consensus-aura = { git = "https://github.com/paritytech/substrate" }
 substrate-client = { git = "https://github.com/paritytech/substrate", default-features = false }
 substrate-finality-grandpa = { git = "https://github.com/paritytech/substrate" }
+substrate-basic-authorship = { git = "https://github.com/paritytech/substrate" }
 template-node-runtime = { path = "runtime" }
 node-executor = { git = "https://github.com/paritytech/substrate" }
 structopt = "0.2.13"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -34,7 +34,7 @@ extern crate substrate_consensus_aura_primitives as consensus_aura;
 use rstd::prelude::*;
 #[cfg(feature = "std")]
 use primitives::bytes;
-use primitives::{AuthorityId, OpaqueMetadata};
+use primitives::{Ed25519AuthorityId, OpaqueMetadata};
 use runtime_primitives::{
 	ApplyResult, transaction_validity::TransactionValidity, Ed25519Signature, generic,
 	traits::{self, BlakeTwo256, Block as BlockT, ProvideInherent},
@@ -85,13 +85,13 @@ pub mod opaque {
 		}
 	}
 	/// Opaque block header type.
-	pub type Header = generic::Header<BlockNumber, BlakeTwo256, generic::DigestItem<Hash, AuthorityId>>;
+	pub type Header = generic::Header<BlockNumber, BlakeTwo256, generic::DigestItem<Hash, Ed25519AuthorityId>>;
 	/// Opaque block type.
 	pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 	/// Opaque block identifier type.
 	pub type BlockId = generic::BlockId<Block>;
 	/// Opaque session key type.
-	pub type SessionKey = AuthorityId;
+	pub type SessionKey = Ed25519AuthorityId;
 }
 
 /// This runtime version.
@@ -144,7 +144,7 @@ impl consensus::Trait for Runtime {
 	/// The position in the block's extrinsics that the note-offline inherent must be placed.
 	const NOTE_OFFLINE_POSITION: u32 = 1;
 	/// The identifier we use to refer to authorities.
-	type SessionKey = AuthorityId;
+	type SessionKey = Ed25519AuthorityId;
 	// The aura module handles offline-reports internally
 	// rather than using an explicit report system.
 	type InherentOfflineReport = ();
@@ -180,7 +180,7 @@ impl upgrade_key::Trait for Runtime {
 }
 
 construct_runtime!(
-	pub enum Runtime with Log(InternalLog: DigestItem<Hash, AuthorityId>) where
+	pub enum Runtime with Log(InternalLog: DigestItem<Hash, Ed25519AuthorityId>) where
 		Block = Block,
 		NodeBlock = opaque::Block,
 		InherentData = BasicInherentData
@@ -218,7 +218,7 @@ impl_runtime_apis! {
 			VERSION
 		}
 
-		fn authorities() -> Vec<AuthorityId> {
+		fn authorities() -> Vec<Ed25519AuthorityId> {
 			Consensus::authorities()
 		}
 

--- a/runtime/wasm/Cargo.lock
+++ b/runtime/wasm/Cargo.lock
@@ -927,7 +927,7 @@ dependencies = [
 [[package]]
 name = "sr-api-macros"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -938,7 +938,7 @@ dependencies = [
 [[package]]
 name = "sr-io"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "environmental 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.9.0 (git+https://github.com/paritytech/trie)",
@@ -953,7 +953,7 @@ dependencies = [
 [[package]]
 name = "sr-primitives"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "integer-sqrt 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -970,7 +970,7 @@ dependencies = [
 [[package]]
 name = "sr-std"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -978,7 +978,7 @@ dependencies = [
 [[package]]
 name = "sr-version"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -991,7 +991,7 @@ dependencies = [
 [[package]]
 name = "srml-aura"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1011,7 +1011,7 @@ dependencies = [
 [[package]]
 name = "srml-balances"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1030,7 +1030,7 @@ dependencies = [
 [[package]]
 name = "srml-consensus"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1047,7 +1047,7 @@ dependencies = [
 [[package]]
 name = "srml-executive"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1063,7 +1063,7 @@ dependencies = [
 [[package]]
 name = "srml-metadata"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1076,7 +1076,7 @@ dependencies = [
 [[package]]
 name = "srml-session"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1096,7 +1096,7 @@ dependencies = [
 [[package]]
 name = "srml-staking"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1119,7 +1119,7 @@ dependencies = [
 [[package]]
 name = "srml-support"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mashup 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1136,7 +1136,7 @@ dependencies = [
 [[package]]
 name = "srml-support-procedural"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1148,7 +1148,7 @@ dependencies = [
 [[package]]
 name = "srml-support-procedural-tools"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1159,7 +1159,7 @@ dependencies = [
 [[package]]
 name = "srml-support-procedural-tools-derive"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1169,7 +1169,7 @@ dependencies = [
 [[package]]
 name = "srml-system"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1186,7 +1186,7 @@ dependencies = [
 [[package]]
 name = "srml-timestamp"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1203,7 +1203,7 @@ dependencies = [
 [[package]]
 name = "srml-upgrade-key"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1232,7 +1232,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "substrate-client"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1261,7 +1261,7 @@ dependencies = [
 [[package]]
 name = "substrate-consensus-aura-primitives"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-io 0.1.0 (git+https://github.com/paritytech/substrate)",
@@ -1275,7 +1275,7 @@ dependencies = [
 [[package]]
 name = "substrate-consensus-common"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1290,7 +1290,7 @@ dependencies = [
 [[package]]
 name = "substrate-executor"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1312,7 +1312,7 @@ dependencies = [
 [[package]]
 name = "substrate-keyring"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1322,7 +1322,7 @@ dependencies = [
 [[package]]
 name = "substrate-primitives"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1348,7 +1348,7 @@ dependencies = [
 [[package]]
 name = "substrate-serializer"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1357,7 +1357,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-machine"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hash-db 0.9.0 (git+https://github.com/paritytech/trie)",
  "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1374,7 +1374,7 @@ dependencies = [
 [[package]]
 name = "substrate-telemetry"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1389,7 +1389,7 @@ dependencies = [
 [[package]]
 name = "substrate-trie"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/substrate#9dfe0066dcb260eead79b0ba7fceeb1fb479ad7b"
+source = "git+https://github.com/paritytech/substrate#3fa7b9a0f831f22a8de762de6b057499214c49e3"
 dependencies = [
  "hash-db 0.9.0 (git+https://github.com/paritytech/trie)",
  "memory-db 0.9.0 (git+https://github.com/paritytech/trie)",

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -1,4 +1,4 @@
-use primitives::{AuthorityId, ed25519};
+use primitives::{Ed25519AuthorityId, ed25519};
 use template_node_runtime::{
 	AccountId, GenesisConfig, ConsensusConfig, TimestampConfig, BalancesConfig, UpgradeKeyConfig,
 };
@@ -75,7 +75,7 @@ impl Alternative {
 	}
 }
 
-fn testnet_genesis(initial_authorities: Vec<AuthorityId>, endowed_accounts: Vec<AccountId>, upgrade_key: AccountId) -> GenesisConfig {
+fn testnet_genesis(initial_authorities: Vec<Ed25519AuthorityId>, endowed_accounts: Vec<AccountId>, upgrade_key: AccountId) -> GenesisConfig {
 	GenesisConfig {
 		consensus: Some(ConsensusConfig {
 			code: include_bytes!("../runtime/wasm/target/wasm32-unknown-unknown/release/template_node_runtime.compact.wasm").to_vec(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ extern crate substrate_network as network;
 #[macro_use]
 extern crate substrate_executor;
 extern crate substrate_transaction_pool as transaction_pool;
+extern crate substrate_basic_authorship as basic_authorship;
 #[macro_use]
 extern crate substrate_service;
 extern crate template_node_runtime;

--- a/src/service.rs
+++ b/src/service.rs
@@ -10,6 +10,7 @@ use substrate_service::{
 	FullClient, LightClient, LightBackend, FullExecutor, LightExecutor,
 	TaskExecutor,
 };
+use basic_authorship::ProposerFactory;
 use node_executor;
 use consensus::{import_queue, start_aura, AuraImportQueue, SlotDuration, NothingExtra};
 use client;
@@ -50,7 +51,7 @@ construct_service_factory! {
 			|service: Self::FullService, executor: TaskExecutor, key: Option<Arc<Pair>>| {
 				if let Some(key) = key {
 					info!("Using authority key {}", key.public());
-					let proposer = Arc::new(substrate_service::ProposerFactory {
+					let proposer = Arc::new(ProposerFactory {
 						client: service.client(),
 						transaction_pool: service.transaction_pool(),
 					});
@@ -62,6 +63,7 @@ construct_service_factory! {
 						client,
 						proposer,
 						service.network(),
+                        service.on_exit(),
 					));
 				}
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -63,7 +63,7 @@ construct_service_factory! {
 						client,
 						proposer,
 						service.network(),
-                        service.on_exit(),
+						service.exit(),
 					));
 				}
 


### PR DESCRIPTION
rel https://github.com/paritytech/substrate/pull/1296.

Makes node template compile with generic `AuthorityId`.