### PR TITLE
Modified  Storage  Macros and Imported rust standard library

### DIFF
--- a/runtime/src/demo.rs
+++ b/runtime/src/demo.rs
@@ -5,6 +5,7 @@ use parity_codec::Encode;
 use srml_support::{StorageValue, dispatch::Result};
 use runtime_primitives::traits::Hash;
 use {balances, system::{self, ensure_signed}};
+use rstd::prelude::*;
 
 pub trait Trait: balances::Trait {}
 
@@ -37,9 +38,10 @@ decl_module! {
 	}
 }
 
+
 decl_storage! {
-	trait Store for Module<T: Trait> as Demo {
-		Payment get(payment) config(): Option<T::Balance>;
-		Pot get(pot): T::Balance;
-	}
+  trait Store for Module<T: Trait> as Demo {
+    Payment get(payment): Option<T::Balance>;
+    Pot get(pot): T::Balance;
+  }
 }


### PR DESCRIPTION
Fixed this error:
```
rror[E0412]: cannot find type `Vec` in this scope
  --> src/demo.rs:47:1
   |
47 | / decl_storage! {
48 | |   trait Store for Module<T: Trait> as Demo {
49 | |     Payment get(payment): Option<T::Balance>;
50 | |     Pot get(pot): T::Balance;
51 | |   }
52 | | }
   | |_^ not found in this scope
```